### PR TITLE
optional support for webhooks.

### DIFF
--- a/controller/ctrldbops.py
+++ b/controller/ctrldbops.py
@@ -23,6 +23,18 @@ def check_paid(address):
     else:
         return False
 
+def get_notifiable():
+    hosts = mongo.hosts.find({
+        "status": "subscribed",
+        "balance": {'$lt': 25},
+        "webhook": {'$not': None}
+    })
+
+    if hosts:
+        return hosts
+    else:
+        return False
+
 
 def get_suspended():
     hosts = mongo.hosts.find({"status": "suspended"})
@@ -62,6 +74,7 @@ def deduct_host(address):
                     }
             }
         )
+
     elif status == "subscribed":
         mongo.hosts.update_one(
             {"address": address},

--- a/wallet/dbops.py
+++ b/wallet/dbops.py
@@ -29,7 +29,7 @@ def create_host(address, plan="basic", image="debian"):
     recordID = mongo.hosts.insert_one(hostdata)
 
 
-def subscribe_host(address, hours):
+def subscribe_host(address, hours, webhook=None):
     host = mongo.hosts.find_one({"address": address})
     balance = host['balance']
 
@@ -39,7 +39,8 @@ def subscribe_host(address, hours):
             "$set":
                 {
                     "status": "subscribed",
-                    "balance": balance + hours
+                    "balance": balance + hours,
+                    "webhook": webhook
                 }
         }
     )

--- a/wallet/wallet.py
+++ b/wallet/wallet.py
@@ -89,7 +89,7 @@ def chargify():
     id = request.get_json()['id']
     invoice_data = get_invoice(id=id)
     #print(invoice_data)
-    address = invoice_data['description']
+    address, notify_url = invoice_data['description'].split('~')
     status = invoice_data['status']
     amount_sats = int(int(invoice_data['msatoshi'])/1000)
     bolt = invoice_data['payreq']
@@ -109,7 +109,7 @@ def chargify():
         add_tx(address=address, txhash=bolt, amount_sats=amount_sats, status='confirmed', chargeid=id,
                prev_outhash='none')
         hours = convert_sats2hours(address, amount_sats)
-        subscribe_host(address, hours)
+        subscribe_host(address, hours, webhook=notify_url or None)
     print("\n\n" + str(find_host(address)) + "\n\n")
     return ''
 


### PR DESCRIPTION
webhooks are sent every time the accountant reduces the hour balance of a host.
only when the host has less than 25 hours left.
intended to be used by an automatic system listening on the other side.
to create a host with a webhook, call /create/<image>?notify=https://myurl.com/