### PR TITLE
update ssh key permission

### DIFF
--- a/how-tos/README.md
+++ b/how-tos/README.md
@@ -64,7 +64,7 @@ Check instance status:
 
 Get instance access key:
 
-`$ curl https://bitclouds.sh/key/hassaleh > ssh.key`
+`$ curl https://bitclouds.sh/key/hassaleh > ssh.key && chmod 400 ssh.key`
 
 Connect to the instance:
 


### PR DESCRIPTION
Permissions 0444 for 'ssh.key' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
Load key "ssh.key": bad permissions